### PR TITLE
Add bulk_transformer callback

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule KafkaGenStage.MixProject do
   def project do
     [
       app: :kafka_gen_stage,
-      version: "1.0.1",
+      version: "1.0.2",
       elixir: "~> 1.7",
       package: package(),
       description: "Klarna's Brod kafka client wrapped into GenStage.",


### PR DESCRIPTION
- gets invoked just before sending a bulk of messages downstream
- takes bulk of messages as a parameter and must return bulk
  of messages