### PR TITLE
Setting EOS only for the last bulk

### DIFF
--- a/test/kafka_gen_stage/consumer_logic_test.exs
+++ b/test/kafka_gen_stage/consumer_logic_test.exs
@@ -8,6 +8,7 @@ defmodule KafkaGenStage.ConsumerLogicTest do
   @msg1 {1, 1_540_458_185_658, "kafkey1", "kafval1"}
   @msg2 {2, 1_540_458_185_659, "kafkey2", "kafval2"}
   @msgs [@msg0, @msg1, @msg2]
+  @empty_queue :queue.new()
 
   defp bulk_transformer(bulk, _is_end_of_stream), do: bulk
 
@@ -22,15 +23,15 @@ defmodule KafkaGenStage.ConsumerLogicTest do
   test "prepare_dispatch with no demand -> no msgs to dispatch" do
     buffer = :queue.from_list(@msgs)
 
-    assert Logic.prepare_dispatch(buffer, 0, nil, false) ==
-             {[], :no_ack, 0, buffer}
+    assert Logic.prepare_dispatch(buffer, 0, nil, false, @empty_queue) ==
+             {[], :no_ack, 0, buffer, @empty_queue}
   end
 
   test "prepare_dispatch with demand and envents -> return demand of events" do
     buffer = :queue.from_list(@msgs)
 
-    {to_send, ack, remaining_demand, remaining_buffer} =
-      Logic.prepare_dispatch(buffer, 2, &bulk_transformer/2, false)
+    {to_send, ack, remaining_demand, remaining_buffer, @empty_queue} =
+      Logic.prepare_dispatch(buffer, 2, &bulk_transformer/2, false, @empty_queue)
 
     assert to_send == [@msg0, @msg1]
     assert ack == 1
@@ -39,12 +40,13 @@ defmodule KafkaGenStage.ConsumerLogicTest do
   end
 
   test "prepare_dispatch - bulk_transformer appends a message" do
-    {to_send, ack, remaining_demand, remaining_buffer} =
+    {to_send, ack, remaining_demand, remaining_buffer, @empty_queue} =
       Logic.prepare_dispatch(
         :queue.from_list(@msgs),
         5,
         fn x, _is_end_of_stream -> x ++ [@msg2] end,
-        false
+        false,
+        @empty_queue
       )
 
     assert to_send == [@msg0, @msg1, @msg2, @msg2]
@@ -54,25 +56,65 @@ defmodule KafkaGenStage.ConsumerLogicTest do
   end
 
   test "prepare_dispatch with more demand than events -> return all events and remaining demand" do
-    expected = {@msgs, 2, 2, :queue.new()}
+    expected = {@msgs, 2, 2, :queue.new(), @empty_queue}
 
     assert Logic.prepare_dispatch(
              :queue.from_list(@msgs),
              5,
              &bulk_transformer/2,
-             false
+             false,
+             @empty_queue
            ) ==
              expected
   end
 
   test "prepare_dispatch empty buffer , generate end_of_stream" do
     assert Logic.prepare_dispatch(
-             :queue.new(),
+             @empty_queue,
              5,
              &add_end_of_stream/2,
-             true
+             true,
+             @empty_queue
            ) ==
-             {[:end_of_stream], :no_ack, 4, :queue.new()}
+             {[:end_of_stream], :no_ack, 4, @empty_queue, @empty_queue}
+  end
+
+  test "end_of_stream is set only for the last bulk" do
+    # if queue still contains some elements after dequeueing, end_of_stream
+    # should not be set for the currently processed bulk
+    {output, _, _, queue, eos_queue} =
+      Logic.prepare_dispatch(
+        :queue.from_list(@msgs),
+        2,
+        &add_end_of_stream/2,
+        true,
+        :queue.from_list([2])
+      )
+
+    assert output == Enum.take(@msgs, 2)
+
+    {output, _, _, _, @empty_queue} =
+      Logic.prepare_dispatch(queue, 2, &add_end_of_stream/2, true, eos_queue)
+
+    assert output == [@msg2, :end_of_stream]
+  end
+
+  test "end_of_stream queue is cleaned properly" do
+    # multiple message sets come from kafka, each is last at that point, and thus multiple offsets
+    # are stored in eos queue
+    # later demand comes and all the messages are dequeued and put into one big GenStage bulk, the #
+    # bulk contains multiple EOS offsets, and thus has to recursively clean the EOS queue
+
+    {_, _, _, _, eos_queue} =
+      Logic.prepare_dispatch(
+        :queue.from_list(@msgs),
+        3,
+        nil,
+        false,
+        :queue.from_list([0, 1, 2, 3])
+      )
+
+    assert :queue.to_list(eos_queue) == [3]
   end
 
   test "enqueue inserts all on infinity end offset" do


### PR DESCRIPTION
Previously EOS flag in bulk transform was set right after the last message from
kafka was received. However, bulks of messages received from kafka do not
correspond to GenStage bulks emitted, therefore, GenStage bulks could have been
mistakenly set as last.

This could occurr in the following situation. Let there be 1000 messages in
kafka topic. Consumer fetches them all in single bulk and puts them to queue.
Since the Consumer is at the end of the topic it sets the `is_end_of_stream` to
`true`. The GenStage demand is 500, thus 500 messages is dequeued and bulk
transformer is called with `is_end_of_stream = true`. However, this is
incorrect, since this bulk is not at the end of stream, there are still messages
waiting in the queue.

The fix adds another mechanism to determine whether GenStage bulk is to be marked as end of stream. The original flag is still used, but only for empty stream detection (i.e. transforming empty bulk, because there are no messages to be processed). For non-empty bulks a new mechanism was added. There is now a queue tracking offsets where end of stream occurred when receiving kafka message sets. When receiving kafka message set which is last the offset of the last message is stored in the queue. When GenStage bulks are created later the queue is used as reference and end of stream is set for bulks containing the offsets from the queue.